### PR TITLE
BZ-11: Валидация модели в конфигурации

### DIFF
--- a/cmd/app/butler.go
+++ b/cmd/app/butler.go
@@ -55,7 +55,7 @@ func (b *Butler) stop(ctx context.Context, svc stopper) {
 		return
 	}
 
-	logrus.Debugf("successfully stopped %s", name)
+	logrus.WithField("name", name).Info("successfully stopped")
 }
 
 // waitForAll ждет завершения всех запущенных горутин.

--- a/internal/config/operation/operation.go
+++ b/internal/config/operation/operation.go
@@ -170,9 +170,9 @@ func LoadOperation(path string) (OperationConfig, error) {
 		operationConfig.Operations[i] = operation
 	}
 
-	logrus.Infof("loaded %d operation(s)", len(operationConfig.Operations))
-	logrus.Infof("loaded %d connection(s)", len(operationConfig.Connections))
-	logrus.Infof("loaded %d storage(s)", len(operationConfig.Storages))
+	logrus.WithField("count", len(operationConfig.Operations)).Info("loaded operations")
+	logrus.WithField("count", len(operationConfig.Connections)).Info("loaded connections")
+	logrus.WithField("count", len(operationConfig.Storages)).Info("loaded storages")
 
 	for _, operation := range operationConfig.Operations {
 		for _, field := range operation.Fields {

--- a/internal/config/operation/validate.go
+++ b/internal/config/operation/validate.go
@@ -1,0 +1,267 @@
+package operation
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Validation - валидация поля.
+type Validation struct {
+	// Тип валидации. Например, max, min, max_length, min_length.
+	Type ValidationType `yaml:"type" validate:"required,oneof=not_empty max_length min_length max min expected_value"`
+	// Ожидаемое значение, если хотим принимать только 1 значение из сообщений. Например, задать, чтобы получать только user_id=1234.
+	Value interface{} `yaml:"value,omitempty"` // не у всех валидаций есть значение (например, not_empty)
+}
+
+// ValidationType - тип валидации.
+type ValidationType string
+
+const (
+	// ValidationTypeNotEmpty - не пустое значение.
+	ValidationTypeNotEmpty ValidationType = "not_empty"
+	// ValidationTypeMaxLength - максимальная длина.
+	ValidationTypeMaxLength ValidationType = "max_length"
+	// ValidationTypeMinLength - минимальная длина.
+	ValidationTypeMinLength ValidationType = "min_length"
+	// ValidationTypeMax - максимальное значение.
+	ValidationTypeMax ValidationType = "max"
+	// ValidationTypeMin - минимальное значение.
+	ValidationTypeMin ValidationType = "min"
+	// ValidationTypeExpectedValue - ожидаемое значение.
+	ValidationTypeExpectedValue ValidationType = "expected_value"
+)
+
+// Rule - правило валидации.
+type Rule string
+
+const (
+	// RuleMin - минимальное значение.
+	RuleMin Rule = "min"
+	// RuleMax - максимальное значение.
+	RuleMax Rule = "max"
+	// RuleMinLength - минимальная длина.
+	RuleMinLength Rule = "min_length"
+	// RuleMaxLength - максимальная длина.
+	RuleMaxLength Rule = "max_length"
+	// RuleNotEmpty - не пустое значение.
+	RuleNotEmpty Rule = "not_empty"
+	// RuleValue - ожидаемое значение.
+	RuleValue Rule = "value"
+)
+
+// мапа с разрешенными валидациями для каждого типа.
+//
+//   - строки: min_length, max_length, not_empty, value
+//   - int64: min, max, value
+//   - uuid: value
+//   - float64: min, max, value
+//   - bool: value
+//
+//nolint:gochecknoglobals // глобальная мапа для избежания switch-case, приватная и используется только в этом модуле.
+var allowedByType = map[FieldType]map[Rule]bool{
+	FieldTypeString: {
+		RuleMin:       false,
+		RuleMax:       false,
+		RuleMinLength: true,
+		RuleMaxLength: true,
+		RuleNotEmpty:  true,
+		RuleValue:     true,
+	},
+	FieldTypeInt64: {
+		RuleMin:       true,
+		RuleMax:       true,
+		RuleMinLength: false,
+		RuleMaxLength: false,
+		RuleNotEmpty:  false,
+		RuleValue:     true,
+	},
+	FieldTypeUUID: {
+		RuleMin:       false,
+		RuleMax:       false,
+		RuleMinLength: false,
+		RuleMaxLength: false,
+		RuleNotEmpty:  true,
+		RuleValue:     true,
+	},
+	FieldTypeFloat64: {
+		RuleMin:       true,
+		RuleMax:       true,
+		RuleMinLength: false,
+		RuleMaxLength: false,
+		RuleNotEmpty:  false,
+		RuleValue:     true,
+	},
+	FieldTypeBool: {
+		RuleMin:       false,
+		RuleMax:       false,
+		RuleMinLength: false,
+		RuleMaxLength: false,
+		RuleNotEmpty:  false,
+		RuleValue:     true,
+	},
+}
+
+func validateFieldConfig(f Field) error {
+	if err := validateRuleCompatibility(f); err != nil {
+		return err
+	}
+
+	if err := validateBoundaryConsistency(f); err != nil {
+		return err
+	}
+
+	if err := validateExpectedValueConsistency(f); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateRuleCompatibility валидирует совместимость правил валидации с типом поля.
+//   - у string не может быть max, min.
+//   - у int64 не может быть max_length, min_length, not_empty.
+//   - у float64 не может быть max, min, not_empty.
+//   - у uuid не может быть max, min.
+//   - у bool не может быть max, min, max_length, min_length, not_empty.
+func validateRuleCompatibility(f Field) error {
+	allowed := allowedByType[f.Type]
+	check := func(rule Rule, enabled bool) error {
+		if enabled && !allowed[rule] {
+			return fmt.Errorf("field %s: rule %q not allowed for type %q", f.Name, rule, f.Type)
+		}
+
+		return nil
+	}
+
+	if err := check(RuleMin, f.Validation.Min != nil); err != nil {
+		return err
+	}
+
+	if err := check(RuleMax, f.Validation.Max != nil); err != nil {
+		return err
+	}
+
+	if err := check(RuleMinLength, f.Validation.MinLength != nil); err != nil {
+		return err
+	}
+
+	if err := check(RuleMaxLength, f.Validation.MaxLength != nil); err != nil {
+		return err
+	}
+
+	if err := check(RuleNotEmpty, f.Validation.NotEmpty); err != nil {
+		return err
+	}
+
+	if err := check(RuleValue, f.Validation.ExpectedValue != nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateBoundaryConsistency валидирует соответствие границ ограничений.
+func validateBoundaryConsistency(f Field) error {
+	if f.Type == FieldTypeInt64 || f.Type == FieldTypeFloat64 {
+		if f.Validation.Min != nil && f.Validation.Max != nil && *f.Validation.Max < *f.Validation.Min {
+			return fmt.Errorf("field %s: max must be > min", f.Name)
+		}
+	}
+
+	if f.Type == FieldTypeString {
+		if f.Validation.MinLength != nil && f.Validation.MaxLength != nil && *f.Validation.MaxLength < *f.Validation.MinLength {
+			return fmt.Errorf("field %s: max_length must be > min_length", f.Name)
+		}
+	}
+
+	return nil
+}
+
+// validateExpectedValueConsistency валидирует соответствие ожидаемого значения типу поля и его ограничениям.
+func validateExpectedValueConsistency(f Field) error {
+	if f.Validation.ExpectedValue == nil {
+		return nil
+	}
+
+	switch f.Type {
+	case FieldTypeString:
+		return validateExpectedValueString(f)
+
+	case FieldTypeInt64:
+		return validateExpectedValueInt64(f)
+
+	case FieldTypeFloat64:
+		return validateExpectedValueFloat64(f)
+
+	case FieldTypeUUID:
+		return validateExpectedValueUUID(f)
+
+	default:
+		return fmt.Errorf("unsupported field type %q", f.Type)
+	}
+}
+
+func validateExpectedValueString(f Field) error {
+	s, ok := f.Validation.ExpectedValue.(string)
+	if !ok {
+		return fmt.Errorf("field %s: value is not string", f.Name)
+	}
+
+	if f.Validation.MinLength != nil && len(s) < int(*f.Validation.MinLength) {
+		return fmt.Errorf("field %s: value shorter than min_length", f.Name)
+	}
+
+	if f.Validation.MaxLength != nil && len(s) > int(*f.Validation.MaxLength) {
+		return fmt.Errorf("field %s: value longer than max_length", f.Name)
+	}
+
+	return nil
+}
+
+func validateExpectedValueInt64(f Field) error {
+	i, ok := f.Validation.ExpectedValue.(int)
+	if !ok {
+		return fmt.Errorf("field %s: value is not int64", f.Name)
+	}
+
+	if f.Validation.Min != nil && i < *f.Validation.Min {
+		return fmt.Errorf("field %s: value is less than min", f.Name)
+	}
+
+	if f.Validation.Max != nil && i > *f.Validation.Max {
+		return fmt.Errorf("field %s: value is greater than max", f.Name)
+	}
+
+	return nil
+}
+
+func validateExpectedValueFloat64(f Field) error {
+	fVal, ok := f.Validation.ExpectedValue.(float64)
+	if !ok {
+		return fmt.Errorf("field %s: value is not float64", f.Name)
+	}
+
+	if f.Validation.Min != nil && fVal < float64(*f.Validation.Min) {
+		return fmt.Errorf("field %s: value is less than min", f.Name)
+	}
+
+	if f.Validation.Max != nil && fVal > float64(*f.Validation.Max) {
+		return fmt.Errorf("field %s: value is greater than max", f.Name)
+	}
+
+	return nil
+}
+
+func validateExpectedValueUUID(f Field) error {
+	s, ok := f.Validation.ExpectedValue.(string)
+	if !ok {
+		return fmt.Errorf("field %s: value is not string", f.Name)
+	}
+
+	if _, err := uuid.Parse(s); err != nil {
+		return fmt.Errorf("field %s: value is not valid uuid", f.Name)
+	}
+
+	return nil
+}

--- a/internal/config/operation/validate_test.go
+++ b/internal/config/operation/validate_test.go
@@ -1,0 +1,808 @@
+package operation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:funlen // это тест
+func TestValidateRuleCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					Max: fromValToPointer(t, 10),
+					Min: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "string: max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					Max: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "string: min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "int64: max_length",
+			f: Field{
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					MaxLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "int64: min_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "float64: max_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					MaxLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "float64: min_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "uuid: max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					MaxLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "uuid: min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					Max: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: max_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					MaxLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: min_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: not_empty",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					NotEmpty: true,
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "bool: value",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					ExpectedValue: true,
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "valid int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+					Max: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "valid float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+					Max: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "valid uuid",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					ExpectedValue: fromValToPointer(t, "123e4567-e89b-12d3-a456-426614174000"),
+					NotEmpty:      true,
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "valid bool",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeBool,
+				Validation: AggregatedValidation{
+					ExpectedValue: true,
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateRuleCompatibility(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+//nolint:funlen // это тест
+func TestValidateBoundaryConsistency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+					Max: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "positive case: float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 3),
+					Max: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 10),
+					Max: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					Min: fromValToPointer(t, 10),
+					Max: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "positive case: string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 3),
+					MaxLength: fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					MinLength: fromValToPointer(t, 10),
+					MaxLength: fromValToPointer(t, 3),
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateBoundaryConsistency(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+//nolint:funlen // это тест
+func TestValidateExpectedValueConsistency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: nil",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: nil,
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "positive case: string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 3),
+					MaxLength:     fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: string: expected value is not string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: string: shorter than min_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 10),
+					MaxLength:     fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: string: longer than max_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 3),
+					MaxLength:     fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "positive case: int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: int64: expected value is not int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: int64: value is less than min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 9,
+					Min:           fromValToPointer(t, 10),
+					Max:           fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: int64: value is greater than max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "positive case: float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 5.5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: float64: expected value is not float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: float64: value is less than min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 9.5,
+					Min:           fromValToPointer(t, 10),
+					Max:           fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: float64: value is greater than max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123.5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "positive case: uuid",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					ExpectedValue: "123e4567-e89b-12d3-a456-426614174000",
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: uuid: expected value is not uuid",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "unsupported case: unsupported field type",
+			f: Field{
+				Name: "field1",
+				Type: "unsupported",
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedValueConsistency(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+//nolint:dupl,funlen // проверяем одни случаи в разных тестах; неважно на длину тестовой функции
+func TestValidateExpectedValueString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 3),
+					MaxLength:     fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: string: expected value is not string",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: string: shorter than min_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 10),
+					MaxLength:     fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: string: longer than max_length",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeString,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+					MinLength:     fromValToPointer(t, 3),
+					MaxLength:     fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedValueString(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+//nolint:dupl,funlen // проверяем одни случаи в разных тестах; неважно на длину тестовой функции
+func TestValidateExpectedValueInt64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: int64: expected value is not int64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: int64: value is less than min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 9,
+					Min:           fromValToPointer(t, 10),
+					Max:           fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: int64: value is greater than max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeInt64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedValueInt64(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+//nolint:dupl,funlen // проверяем одни случаи в разных тестах; неважно на длину тестовой функции
+func TestValidateExpectedValueFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 5.5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 10),
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: float64: expected value is not float64",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: "string",
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: float64: value is less than min",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 9.5,
+					Min:           fromValToPointer(t, 10),
+					Max:           fromValToPointer(t, 11),
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "negative case: float64: value is greater than max",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeFloat64,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123.5,
+					Min:           fromValToPointer(t, 3),
+					Max:           fromValToPointer(t, 4),
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedValueFloat64(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+func TestValidateExpectedValueUUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		f       Field
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "positive case: uuid",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					ExpectedValue: "123e4567-e89b-12d3-a456-426614174000",
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "negative case: uuid: expected value is not uuid",
+			f: Field{
+				Name: "field1",
+				Type: FieldTypeUUID,
+				Validation: AggregatedValidation{
+					ExpectedValue: 123,
+				},
+			},
+			wantErr: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExpectedValueUUID(test.f)
+			test.wantErr(t, err)
+		})
+	}
+}
+
+func fromValToPointer[T any](t *testing.T, val T) *T {
+	t.Helper()
+	return &val
+}

--- a/internal/service/operation/message.go
+++ b/internal/service/operation/message.go
@@ -15,10 +15,18 @@ func (s *Service) readMessages(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.Debugf("operation %s: context done", s.cfg.Name)
+			logrus.WithFields(logrus.Fields{
+				"name":       s.cfg.Name,
+				"connection": s.cfg.Request.From,
+			}).Debug("operation: context done")
+
 			return
 		case <-s.quitChan:
-			logrus.Debugf("operation %s: quit channel received", s.cfg.Name)
+			logrus.WithFields(logrus.Fields{
+				"name":       s.cfg.Name,
+				"connection": s.cfg.Request.From,
+			}).Debug("operation: quit channel received")
+
 			return
 		case msg, ok := <-s.msgChan:
 			if !ok {

--- a/internal/service/operation/operation.go
+++ b/internal/service/operation/operation.go
@@ -82,7 +82,9 @@ func (s *Service) Run(ctx context.Context) error {
 
 // Stop закрывает сервис.
 func (s *Service) Stop(_ context.Context) error {
-	logrus.Debugf("operation %s: closing", s.cfg.Name)
+	logrus.WithFields(logrus.Fields{
+		"name": s.cfg.Name,
+	}).Debug("operation: closing")
 
 	close(s.quitChan)
 

--- a/internal/service/operation/validate.go
+++ b/internal/service/operation/validate.go
@@ -7,36 +7,27 @@ import (
 )
 
 func (s *Service) validateMessage(msg map[string]interface{}) error {
-	err := s.validateFields(msg)
+	err := s.validateFieldsCount(msg)
 	if err != nil {
 		return fmt.Errorf("operation: error validate fields: %w", err)
 	}
 
 	err = s.validateFieldVals(msg)
 	if err != nil {
-		return fmt.Errorf("operation: error validate fields types: %w", err)
+		return fmt.Errorf("operation: error validate fields values: %w", err)
 	}
 
 	return nil
 }
 
-func (s *Service) validateFields(msg map[string]interface{}) error {
-	visited := make(map[string]bool)
-
+func (s *Service) validateFieldsCount(msg map[string]interface{}) error {
+	// проверить, что все обязательные поля присутствуют в сообщении
 	for _, field := range s.cfg.Fields {
-		if field.Required && msg[field.Name] == nil {
-			return fmt.Errorf("field %s is required", field.Name)
+		if field.Required {
+			if _, ok := msg[field.Name]; !ok {
+				return fmt.Errorf("field %s is required", field.Name)
+			}
 		}
-
-		if visited[field.Name] {
-			continue
-		}
-
-		visited[field.Name] = true
-	}
-
-	if len(visited) != len(s.cfg.Fields) {
-		return fmt.Errorf("some fields are missing")
 	}
 
 	return nil

--- a/internal/service/operation/validate_test.go
+++ b/internal/service/operation/validate_test.go
@@ -146,7 +146,7 @@ func TestValidateMessage(t *testing.T) {
 }
 
 //nolint:funlen // это тест
-func TestValidateFields(t *testing.T) {
+func TestValidateFieldsCount(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -268,7 +268,7 @@ func TestValidateFields(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.svc.validateFields(tt.msg)
+			err := tt.svc.validateFieldsCount(tt.msg)
 			tt.wantErr(t, err)
 		})
 	}

--- a/internal/service/validator/types.go
+++ b/internal/service/validator/types.go
@@ -1,0 +1,115 @@
+package validator
+
+import (
+	"db-worker/internal/config/operation"
+	"fmt"
+)
+
+func validateInt64Value(field operation.Field, val int64) error {
+	validation := field.Validation
+
+	if validation.ExpectedValue != nil {
+		expectedValue, _ := validation.ExpectedValue.(int64)
+		if expectedValue != val {
+			return fmt.Errorf("field %s must be %d, but got %d", field.Name, expectedValue, val)
+		}
+	}
+
+	// не проверяем на not_empty, т.к. 0 - тоже валидное значение
+	// не проверяем на max_length, min_length, т.к. это недопустимо для int64
+
+	if field.Validation.Max != nil {
+		if val > int64(*field.Validation.Max) {
+			return fmt.Errorf("field %s must be less than %d, but got %d", field.Name, *field.Validation.Max, val)
+		}
+	}
+
+	if field.Validation.Min != nil {
+		if val < int64(*field.Validation.Min) {
+			return fmt.Errorf("field %s must be greater than %d, but got %d", field.Name, *field.Validation.Min, val)
+		}
+	}
+
+	return nil
+}
+
+func validateFloat64Value(field operation.Field, val float64) error {
+	validation := field.Validation
+
+	if validation.ExpectedValue != nil {
+		expectedValue, ok := validation.ExpectedValue.(float64)
+		if !ok {
+			expValueInt, ok := validation.ExpectedValue.(int)
+			if !ok {
+				return fmt.Errorf("field %s: invalid type of expected value", field.Name)
+			}
+
+			expectedValue = float64(expValueInt)
+		}
+
+		if expectedValue != val {
+			return fmt.Errorf("field %s must be %f, but got %f", field.Name, expectedValue, val)
+		}
+	}
+
+	// не проверяем на not_empty, т.к. 0 - тоже валидное значение
+	// не проверяем на max_length, min_length, т.к. это недопустимо для float64
+
+	if field.Validation.Max != nil {
+		if val > float64(*field.Validation.Max) {
+			return fmt.Errorf("field %s must be less than %v, but got %f", field.Name, *field.Validation.Max, val)
+		}
+	}
+
+	if field.Validation.Min != nil {
+		if val < float64(*field.Validation.Min) {
+			return fmt.Errorf("field %s must be greater than %v, but got %f", field.Name, *field.Validation.Min, val)
+		}
+	}
+
+	return nil
+}
+
+func validateStringValue(field operation.Field, val string) error {
+	len := len(val)
+
+	validation := field.Validation
+
+	if validation.ExpectedValue != nil {
+		expectedValue, _ := validation.ExpectedValue.(string)
+		if expectedValue != val {
+			return fmt.Errorf("field %s must be %s, but got %s", field.Name, expectedValue, val)
+		}
+	}
+
+	if field.Validation.NotEmpty {
+		if len == 0 {
+			return fmt.Errorf("field %s must be not empty", field.Name)
+		}
+	}
+
+	if field.Validation.MaxLength != nil {
+		if len > int(*field.Validation.MaxLength) {
+			return fmt.Errorf("length of field %s must be less than %d, but got %d", field.Name, *field.Validation.MaxLength, len)
+		}
+	}
+
+	if field.Validation.MinLength != nil {
+		if len < int(*field.Validation.MinLength) {
+			return fmt.Errorf("length of field %s must be greater than %d, but got %d", field.Name, *field.Validation.MinLength, len)
+		}
+	}
+
+	return nil
+}
+
+func validateBoolValue(field operation.Field, val bool) error {
+	if field.Validation.ExpectedValue != nil {
+		expectedValue, _ := field.Validation.ExpectedValue.(bool)
+		if expectedValue != val {
+			return fmt.Errorf("field %s must be %t, but got %t", field.Name, expectedValue, val)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/validator/validator.go
+++ b/internal/service/validator/validator.go
@@ -59,7 +59,7 @@ func (v *validator) Validate() error {
 	return validate(v.field, v.val)
 }
 
-// forField возвращает валидатор для поля.
+// forField возвращает валидатор для поля в зависимости от типа поля.
 func forField(field operation.Field) (validatorFunc, error) {
 	validator, ok := validatorsMap[field.Type]
 	if !ok {
@@ -70,46 +70,53 @@ func forField(field operation.Field) (validatorFunc, error) {
 }
 
 func validateInt64(field operation.Field, val any) error {
-	_, ok := val.(int64)
+	v, ok := val.(int64)
 	if !ok {
 		return validateFloat64(field, val) // иногда int64 приходит как float64
 	}
 
-	return nil
+	return validateInt64Value(field, v)
 }
 
 func validateFloat64(field operation.Field, val any) error {
-	_, ok := val.(float64)
+	v, ok := val.(float64)
 	if !ok {
 		return fmt.Errorf("field %s is not a float64", field.Name)
 	}
 
-	return nil
+	return validateFloat64Value(field, v)
 }
 
 func validateBool(field operation.Field, val any) error {
-	_, ok := val.(bool)
+	v, ok := val.(bool)
 	if !ok {
 		return fmt.Errorf("field %s is not a bool", field.Name)
 	}
 
-	return nil
+	return validateBoolValue(field, v)
 }
 
 func validateUUID(field operation.Field, val any) error {
-	_, ok := val.(uuid.UUID)
+	v, ok := val.(uuid.UUID)
 	if !ok {
 		return fmt.Errorf("field %s is not a uuid", field.Name)
 	}
+
+	_, err := uuid.Parse(v.String())
+	if err != nil {
+		return fmt.Errorf("field %s must be a valid uuid", field.Name)
+	}
+
+	// здесь нет валидации, т.к. uuid.Parse покрывает все случаи
 
 	return nil
 }
 
 func validateString(field operation.Field, val any) error {
-	_, ok := val.(string)
+	v, ok := val.(string)
 	if !ok {
 		return fmt.Errorf("field %s is not a string", field.Name)
 	}
 
-	return nil
+	return validateStringValue(field, v)
 }

--- a/internal/service/worker/rabbit/service.go
+++ b/internal/service/worker/rabbit/service.go
@@ -249,11 +249,11 @@ func (s *Worker) Address() string {
 func (s *Worker) Stop(_ context.Context) error {
 	err := s.channel.Close()
 	if err != nil {
-		logrus.Errorf("worker: error closing channel rabbit mq: %+v", err)
+		return fmt.Errorf("worker: error closing channel rabbit mq: %w", err)
 	}
 
 	if err := s.conn.Close(); err != nil {
-		logrus.Errorf("worker: error closing connection rabbit mq: %+v", err)
+		return fmt.Errorf("worker: error closing connection rabbit mq: %w", err)
 	}
 
 	close(s.quitChan)

--- a/operations.example.yaml
+++ b/operations.example.yaml
@@ -8,9 +8,20 @@ operations: # операции, которые можно выполнить н�
       - name: user_id
         type: int64
         required: true
+        validation:
+          - type: min
+            value: 100
+          - type: max
+            value: 1000
       - name: text
         type: string
         required: true
+        validation:
+          - type: not_empty
+          - type: max_length
+            value: 3
+          - type: min_length
+            value: 1
     request: # каким образом будет получен запрос на операцию
       from: rabbit_notes_create # соединение, из которого будет получен запрос. должно быть в списке connections
         


### PR DESCRIPTION
добавлены ограничения на значения в конфигурации. 
Теперь можно указать ожидаемое значения для поля или диапазон значений, также минимальную и максимальную длину, также исключить пустые значения.
однако это остается необязательным, и можно не добавлять такие ограничения и принимать все значения

во втором коммите немного поправлены старые логи